### PR TITLE
feat(worker): harden Go worker with bug fixes, DI cleanup, and unit tests

### DIFF
--- a/makefile
+++ b/makefile
@@ -70,10 +70,12 @@ push-%:
 	@IMAGE_NAME=$($*_IMAGE_NAME) IMAGE_TAG=$(VERSION) bash scripts/push-image.sh
 	@echo "====== Done: $* ======"
 
-# special case for worker-golang
+# special case for worker-golang (Go: build test image from source, not base binary)
 test-worker-golang:
-	@echo "====== Testing worker: golang ======"
-	@echo "Not implemented yet, skipping..."
+	@echo "====== Testing: worker-golang ======"
+	@docker buildx build -t safezone-worker:$(VERSION)_test -f services/worker-golang/Dockerfile.test .
+	@docker run --rm safezone-worker:$(VERSION)_test
+	@docker rmi safezone-worker:$(VERSION)_test || true
 	@echo "====== Done: worker-golang ======"
 
 # special case for data-ingestor (only integration-test)

--- a/services/worker-golang/Dockerfile.test
+++ b/services/worker-golang/Dockerfile.test
@@ -1,0 +1,6 @@
+FROM golang:1.24-bookworm
+WORKDIR /module
+COPY services/worker-golang/go.mod services/worker-golang/go.sum /module/
+RUN go mod download
+COPY services/worker-golang/app /module/app
+CMD ["go", "test", "./..."]

--- a/services/worker-golang/app/adapter/mockSource.go
+++ b/services/worker-golang/app/adapter/mockSource.go
@@ -2,58 +2,43 @@ package adapter
 
 import (
 	"context"
-	"fmt"
 
-	"time"
-
-	"go.uber.org/zap"
-	"safezone.service.worker-golang/app/pkg/logger"
 	"safezone.service.worker-golang/app/schema"
 )
 
-// MockSource is a mock implementation of EventSource for testing purposes.
+type mockResult struct {
+	event *schema.CovidEvent
+	err   error
+}
+
+// MockSource is a controllable EventSource for testing.
+// Push events via Push() or inject errors via PushError().
+// GetEvent blocks until an event/error is available or ctx is done.
 type MockSource struct {
-	Count  int
-	Curr   int
-	Logger *logger.ContextLogger
+	ch chan mockResult
+}
+
+func NewMockSource() *MockSource {
+	return &MockSource{ch: make(chan mockResult, 100)}
+}
+
+func (m *MockSource) Push(event *schema.CovidEvent) {
+	m.ch <- mockResult{event: event}
+}
+
+func (m *MockSource) PushError(err error) {
+	m.ch <- mockResult{err: err}
 }
 
 func (m *MockSource) GetEvent(ctx context.Context) (*schema.CovidEvent, error) {
-	if m.Curr < m.Count {
-		time.Sleep(100 * time.Millisecond) // simulate some processing delay
-
-		m.Logger.Debug(ctx, "Generating mock event",
-			zap.Int("current_event_index", m.Curr),
-			zap.Int("total_events", m.Count))
-
-		// create a mock event
-		event := &schema.CovidEvent{
-			EventType: "mock_event",
-			EventTime: time.Now().Unix(),
-			TraceID:   fmt.Sprintf("mock_trace_%d", m.Curr),
-			Version:   "0.1.0",
-		}
-		event.Payload.Date = fmt.Sprintf("2023-10-%02d", m.Curr+1)
-		event.Payload.City = "MockCity"
-		event.Payload.Region = "MockRegion"
-		event.Payload.Cases = 100 + m.Curr
-		m.Curr++
-		return event, nil
-	}
-	// simulate a blocking call
-	for {
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		case <-time.After(3 * time.Second):
-
-		}
-
+	select {
+	case r := <-m.ch:
+		return r.event, r.err
+	case <-ctx.Done():
+		return nil, ctx.Err()
 	}
 }
 
 func (m *MockSource) Close(ctx context.Context) error {
-	m.Logger.Info(ctx, "Closing mock event source",
-		zap.Int("total_events_generated", m.Curr))
 	return nil
 }

--- a/services/worker-golang/app/main.go
+++ b/services/worker-golang/app/main.go
@@ -12,7 +12,7 @@ import (
 )
 
 func main() {
-	cfx, err := config.Load()
+	cfg, err := config.Load()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: Failed to load configuration: %v\n", err)
 		os.Exit(1)
@@ -21,21 +21,15 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
 
-	logger := logger.NewContextLogger(cfx.ServiceName, cfx.ServiceVersion, cfx.Environment)
+	log := logger.NewContextLogger(cfg.ServiceName, cfg.ServiceVersion, cfg.Environment)
+	log.Info(ctx, "Worker-golang service started")
 
-	logger.Info(ctx, "Worker-golang service started")
-
-	workers := make([]*service.Worker, 0, cfx.WorkerCount)
-
-	factory := &service.WorkerFactory{Logger: logger, Config: cfx}
-	for i := 0; i < cfx.WorkerCount; i++ {
-		workers = append(workers, factory.CreateWorker(i))
+	workers := make([]*service.Worker, 0, cfg.WorkerCount)
+	for i := 0; i < cfg.WorkerCount; i++ {
+		workers = append(workers, service.NewWorker(i, cfg, log))
 	}
 
-	orchestrator := &service.Orchestrator{
-		Workers: workers,
-	}
-	orchestrator.RunParallel(ctx, cfx.ParallelN)
+	service.RunWorkers(ctx, workers, cfg.ParallelN)
 
-	logger.Info(ctx, "Worker-golang service completed")
+	log.Info(ctx, "Worker-golang service completed")
 }

--- a/services/worker-golang/app/pkg/cache/cache.go
+++ b/services/worker-golang/app/pkg/cache/cache.go
@@ -15,7 +15,7 @@ func DebugString(label, s string) {
 	fmt.Printf("%s : [%s] HEX: [% x]\n", label, s, []byte(s))
 }
 
-func (c *Cache) NewCache(db *sqlx.DB) *Cache {
+func NewCache(db *sqlx.DB) *Cache {
 	cityRows, _ := db.Queryx("SELECT id, name FROM cities")
 	cityMap := make(map[string]int)
 	for cityRows.Next() {

--- a/services/worker-golang/app/schema/validator.go
+++ b/services/worker-golang/app/schema/validator.go
@@ -5,17 +5,23 @@ import (
 	"regexp"
 
 	"go.uber.org/zap"
-	"safezone.service.worker-golang/app/pkg/cache"
 	"safezone.service.worker-golang/app/pkg/logger"
 )
+
+// CacheReader is the read-only interface CovidValidator needs for city/region lookups.
+// *cache.Cache satisfies this interface.
+type CacheReader interface {
+	GetCityID(city string) int
+	GetRegionID(cityID int, region string) int
+}
 
 type CovidValidator struct {
 	Logger      *logger.ContextLogger
 	datePattern *regexp.Regexp // YYYY-MM-DD 格式
-	cache       *cache.Cache
+	cache       CacheReader
 }
 
-func NewCovidValidator(logger *logger.ContextLogger, cache *cache.Cache) *CovidValidator {
+func NewCovidValidator(logger *logger.ContextLogger, cache CacheReader) *CovidValidator {
 	return &CovidValidator{
 		Logger:      logger,
 		datePattern: regexp.MustCompile(`^\d{4}-\d{2}-\d{2}$`),

--- a/services/worker-golang/app/schema/validator_test.go
+++ b/services/worker-golang/app/schema/validator_test.go
@@ -1,0 +1,91 @@
+package schema_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"safezone.service.worker-golang/app/pkg/logger"
+	"safezone.service.worker-golang/app/schema"
+)
+
+type mockCache struct {
+	cities  map[string]int
+	regions map[string]int // key: "cityID|regionName"
+}
+
+func (m *mockCache) GetCityID(city string) int {
+	if id, ok := m.cities[city]; ok {
+		return id
+	}
+	return -1
+}
+
+func (m *mockCache) GetRegionID(cityID int, region string) int {
+	key := fmt.Sprintf("%d|%s", cityID, region)
+	if id, ok := m.regions[key]; ok {
+		return id
+	}
+	return -1
+}
+
+func newValidator() *schema.CovidValidator {
+	cache := &mockCache{
+		cities:  map[string]int{"Taipei": 1},
+		regions: map[string]int{"1|Zhongzheng": 10},
+	}
+	return schema.NewCovidValidator(
+		logger.NewContextLogger("test", "0.0.0", "test"),
+		cache,
+	)
+}
+
+func validEvent() schema.CovidEvent {
+	e := schema.CovidEvent{TraceID: "t1"}
+	e.Payload.Date = "2024-01-01"
+	e.Payload.City = "Taipei"
+	e.Payload.Region = "Zhongzheng"
+	e.Payload.Cases = 10
+	return e
+}
+
+func TestValidator_ValidEvent(t *testing.T) {
+	v := newValidator()
+	if !v.Validate(context.Background(), validEvent()) {
+		t.Fatal("expected valid event to pass")
+	}
+}
+
+func TestValidator_InvalidDateFormat(t *testing.T) {
+	v := newValidator()
+	e := validEvent()
+	e.Payload.Date = "01/01/2024" // wrong format
+	if v.Validate(context.Background(), e) {
+		t.Fatal("expected invalid date to fail")
+	}
+}
+
+func TestValidator_UnknownCityOrRegion(t *testing.T) {
+	v := newValidator()
+
+	unknown := validEvent()
+	unknown.Payload.City = "UnknownCity"
+	if v.Validate(context.Background(), unknown) {
+		t.Fatal("expected unknown city to fail")
+	}
+
+	wrongRegion := validEvent()
+	wrongRegion.Payload.Region = "UnknownRegion"
+	if v.Validate(context.Background(), wrongRegion) {
+		t.Fatal("expected unknown region to fail")
+	}
+}
+
+func TestValidator_NegativeCases(t *testing.T) {
+	v := newValidator()
+	e := validEvent()
+	e.Payload.Cases = -1
+	if v.Validate(context.Background(), e) {
+		t.Fatal("expected negative cases to fail")
+	}
+}

--- a/services/worker-golang/app/service/orchestrator.go
+++ b/services/worker-golang/app/service/orchestrator.go
@@ -3,40 +3,32 @@ package service
 import (
 	"context"
 	"sync"
-
-	"go.uber.org/zap"
 )
 
-type Orchestrator struct {
-	Logger  *zap.Logger
-	Workers []*Worker
-}
-
-func (o *Orchestrator) Run(ctx context.Context) error {
-	return o.RunParallel(ctx, 1)
-}
-
-func (o *Orchestrator) RunParallel(ctx context.Context, parallelN int) error {
+// RunWorkers runs workers with at most parallelN goroutines concurrently.
+//
+// NOTE: Each Worker holds an independent Kafka consumer group member.
+// Effective parallelism is bounded by topic partition count, not parallelN.
+// This is intentional: partition-level fan-out and within-pod concurrency
+// design are deferred to v0.5.0 (#23).
+//
+// Horizontal scaling (pod count) is managed externally by KEDA.
+func RunWorkers(ctx context.Context, workers []*Worker, parallelN int) {
 	sem := make(chan struct{}, parallelN)
 	var wg sync.WaitGroup
 
-	for _, w := range o.Workers {
+	for _, w := range workers {
 		wg.Add(1)
 		sem <- struct{}{}
 		go func(worker *Worker) {
 			defer wg.Done()
 			defer func() { <-sem }()
 
-			err := worker.Run(ctx)
-			if err != nil {
-				o.Logger.Error("Error occurred while running worker",
-					zap.Int("worker_id", worker.ID),
-					zap.Error(err))
-				return
+			if err := worker.Run(ctx); err != nil {
+				worker.Logger.Error(ctx, "worker exited with error")
 			}
 			worker.Close(ctx)
 		}(w)
 	}
 	wg.Wait()
-	return nil
 }

--- a/services/worker-golang/app/service/worker.go
+++ b/services/worker-golang/app/service/worker.go
@@ -44,11 +44,9 @@ func (w *Worker) Run(ctx context.Context) error {
 	}()
 
 	for {
-
 		readCtx, cancel := context.WithTimeout(ctx, w.Config.FlushInterval)
-		defer cancel()
-
 		event, err := w.Source.GetEvent(readCtx)
+		cancel()
 
 		if err != nil {
 			if errors.Is(err, context.DeadlineExceeded) {
@@ -57,7 +55,6 @@ func (w *Worker) Run(ctx context.Context) error {
 				}
 				// timeout reached, flush if there are events in the buffer
 				w.Sink.Flush(ctx, &buffer)
-
 			} else if errors.Is(err, context.Canceled) {
 				w.Logger.Info(ctx, "Get context canceled, stopping worker",
 					zap.String("event", "context canceled"))
@@ -66,38 +63,26 @@ func (w *Worker) Run(ctx context.Context) error {
 				w.Logger.Error(ctx, "Failed to get event from source", zap.Error(err))
 				return err
 			}
-		} else {
-			// if the event can't pass validation, skip it
-			// future: we add the bad event to a dead-letter queue
-			if w.Validator != nil && !w.Validator.Validate(ctx, *event) {
-				w.Logger.Warn(ctx, "An event validation failed, skipping event",
-					zap.String("event", "Event validation failed"))
-				continue
-			}
-			// if the event is valid, add trace to the context for logging
-			ctx = context.WithValue(ctx, w.Logger.TraceIDKey, event.TraceID)
-
-			w.Logger.Info(ctx, "Received event from source",
-				zap.String("event", "Event received"))
-
-			buffer = append(buffer, *event)
+			continue
 		}
-		// stop timer during flushing
-		cancel()
+
+		// if the event can't pass validation, skip it
+		// future: we add the bad event to a dead-letter queue
+		if w.Validator != nil && !w.Validator.Validate(ctx, *event) {
+			w.Logger.Warn(ctx, "An event validation failed, skipping event",
+				zap.String("event", "Event validation failed"))
+			continue
+		}
+		// if the event is valid, add trace to the context for logging
+		ctx = context.WithValue(ctx, w.Logger.TraceIDKey, event.TraceID)
+		w.Logger.Info(ctx, "Received event from source",
+			zap.String("event", "Event received"))
+		buffer = append(buffer, *event)
 
 		if len(buffer) >= w.Config.BatchSize {
-
-			w.Sink.Flush(ctx, &buffer)
-
-			if err != nil {
-				if errors.Is(err, context.Canceled) {
-					w.Logger.Info(ctx, "Get context canceled, stopping worker",
-						zap.String("event", "context canceled"))
-					return nil
-				} else {
-					w.Logger.Error(ctx, "Failed to flush events", zap.Error(err))
-					return err
-				}
+			if err := w.Sink.Flush(ctx, &buffer); err != nil {
+				w.Logger.Error(ctx, "Failed to flush events", zap.Error(err))
+				return err
 			}
 		}
 	}

--- a/services/worker-golang/app/service/workerFactory.go
+++ b/services/worker-golang/app/service/workerFactory.go
@@ -5,44 +5,25 @@ import (
 	"github.com/jmoiron/sqlx"
 	"safezone.service.worker-golang/app/adapter"
 	"safezone.service.worker-golang/app/config"
-	"safezone.service.worker-golang/app/pkg/cache"
+	cachepkg "safezone.service.worker-golang/app/pkg/cache"
 	"safezone.service.worker-golang/app/pkg/logger"
 	"safezone.service.worker-golang/app/schema"
 	"safezone.service.worker-golang/app/strategy"
 )
 
-type WorkerFactory struct {
-	Logger *logger.ContextLogger
-	Config *config.Config
-}
-
-func (f *WorkerFactory) CreateWorker(id int) *Worker {
-	var db *sqlx.DB
-	var cache *cache.Cache
-	var src adapter.EventSource
-	var validator *schema.CovidValidator
-	var sink strategy.EventSink
-
-	switch f.Config.Environment {
-	case "TEST":
-		src = &adapter.MockSource{Count: 10, Logger: f.Logger}
-		sink = &strategy.MockSink{Logger: f.Logger}
-	default:
-		db = sqlx.MustConnect("pgx", f.Config.DBUrl)
-		cache = cache.NewCache(db)
-		src = adapter.NewKafkaSource(f.Logger, f.Config.KafkaBroker, f.Config.KafkaGroupID, f.Config.KafkaTopic)
-		validator = schema.NewCovidValidator(f.Logger, cache)
-		sink = strategy.NewDBSink(f.Logger, db, cache)
-	}
-
+// NewWorker creates a production Worker wired to Kafka and PostgreSQL.
+// For testing, construct Worker directly with mock Source/Sink.
+func NewWorker(id int, cfg *config.Config, log *logger.ContextLogger) *Worker {
+	db := sqlx.MustConnect("pgx", cfg.DBUrl)
+	cache := cachepkg.NewCache(db)
 	return &Worker{
 		DB:        db,
 		Cache:     cache,
-		Source:    src,
-		Validator: validator,
-		Sink:      sink,
-		Config:    f.Config,
-		Logger:    f.Logger,
+		Source:    adapter.NewKafkaSource(log, cfg.KafkaBroker, cfg.KafkaGroupID, cfg.KafkaTopic),
+		Validator: schema.NewCovidValidator(log, cache),
+		Sink:      strategy.NewDBSink(log, db, cache),
+		Config:    cfg,
+		Logger:    log,
 		ID:        id,
 	}
 }

--- a/services/worker-golang/app/service/worker_test.go
+++ b/services/worker-golang/app/service/worker_test.go
@@ -1,0 +1,216 @@
+package service_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"safezone.service.worker-golang/app/adapter"
+	"safezone.service.worker-golang/app/config"
+	"safezone.service.worker-golang/app/pkg/logger"
+	"safezone.service.worker-golang/app/schema"
+	"safezone.service.worker-golang/app/service"
+	"safezone.service.worker-golang/app/strategy"
+)
+
+func testLogger() *logger.ContextLogger {
+	return logger.NewContextLogger("test", "0.0.0", "test")
+}
+
+func newTestWorker(src adapter.EventSource, sink strategy.EventSink) *service.Worker {
+	return &service.Worker{
+		Source: src,
+		Sink:   sink,
+		Config: &config.Config{
+			BatchSize:     3,
+			FlushInterval: 50 * time.Millisecond,
+		},
+		Logger: testLogger(),
+		ID:     0,
+	}
+}
+
+func makeEvent(i int) *schema.CovidEvent {
+	e := &schema.CovidEvent{
+		EventType: "test",
+		TraceID:   fmt.Sprintf("trace-%d", i),
+	}
+	e.Payload.Date = "2024-01-01"
+	e.Payload.City = "Taipei"
+	e.Payload.Region = "Zhongzheng"
+	e.Payload.Cases = i
+	return e
+}
+
+func runAsync(ctx context.Context, w *service.Worker) <-chan error {
+	done := make(chan error, 1)
+	go func() { done <- w.Run(ctx) }()
+	return done
+}
+
+// TestWorker_BatchFlush: exactly BatchSize events → one flush with all events
+func TestWorker_BatchFlush(t *testing.T) {
+	src := adapter.NewMockSource()
+	sink := &strategy.MockSink{}
+	w := newTestWorker(src, sink)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := runAsync(ctx, w)
+
+	for i := 0; i < 3; i++ {
+		src.Push(makeEvent(i))
+	}
+	time.Sleep(20 * time.Millisecond) // let worker consume and flush
+	cancel()
+	<-done
+
+	if sink.FlushedCount() != 1 {
+		t.Fatalf("expected 1 flush, got %d", sink.FlushedCount())
+	}
+	if len(sink.Flushed[0]) != 3 {
+		t.Fatalf("expected 3 events in flush, got %d", len(sink.Flushed[0]))
+	}
+}
+
+// TestWorker_TimeoutFlush: events < BatchSize → FlushInterval triggers flush
+func TestWorker_TimeoutFlush(t *testing.T) {
+	src := adapter.NewMockSource()
+	sink := &strategy.MockSink{}
+	w := newTestWorker(src, sink)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := runAsync(ctx, w)
+
+	src.Push(makeEvent(0))
+	src.Push(makeEvent(1))
+	time.Sleep(150 * time.Millisecond) // wait past FlushInterval (50ms)
+	cancel()
+	<-done
+
+	if sink.FlushedCount() < 1 {
+		t.Fatal("expected at least 1 flush from timeout, got 0")
+	}
+
+	total := 0
+	for _, batch := range sink.Flushed {
+		total += len(batch)
+	}
+	if total != 2 {
+		t.Fatalf("expected 2 total events flushed, got %d", total)
+	}
+}
+
+// TestWorker_EmptyBufferOnTimeout: no events → timeout fires but no flush
+func TestWorker_EmptyBufferOnTimeout(t *testing.T) {
+	src := adapter.NewMockSource()
+	sink := &strategy.MockSink{}
+	w := newTestWorker(src, sink)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := runAsync(ctx, w)
+
+	time.Sleep(150 * time.Millisecond)
+	cancel()
+	<-done
+
+	if sink.FlushedCount() != 0 {
+		t.Fatalf("expected 0 flushes on empty buffer, got %d", sink.FlushedCount())
+	}
+}
+
+// TestWorker_GracefulShutdown: cancel with buffered events → deferred flush
+func TestWorker_GracefulShutdown(t *testing.T) {
+	src := adapter.NewMockSource()
+	sink := &strategy.MockSink{}
+	w := newTestWorker(src, sink)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := runAsync(ctx, w)
+
+	src.Push(makeEvent(0))
+	src.Push(makeEvent(1))
+	time.Sleep(20 * time.Millisecond) // let events land in buffer
+	cancel()
+	<-done
+
+	total := 0
+	for _, batch := range sink.Flushed {
+		total += len(batch)
+	}
+	if total != 2 {
+		t.Fatalf("expected 2 total events on graceful shutdown, got %d", total)
+	}
+}
+
+// TestWorker_ValidationReject: invalid events skipped, valid events processed
+func TestWorker_ValidationReject(t *testing.T) {
+	src := adapter.NewMockSource()
+	sink := &strategy.MockSink{}
+	w := newTestWorker(src, sink)
+
+	// wire up a validator with a mock cache that knows one valid city/region
+	mockCache := &mockCacheReader{
+		cities:  map[string]int{"Taipei": 1},
+		regions: map[string]int{"1|Zhongzheng": 10},
+	}
+	w.Validator = schema.NewCovidValidator(testLogger(), mockCache)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := runAsync(ctx, w)
+
+	valid := makeEvent(0) // Taipei/Zhongzheng — valid
+	invalid := makeEvent(1)
+	invalid.Payload.City = "UnknownCity"
+
+	src.Push(valid)
+	src.Push(invalid)
+	time.Sleep(150 * time.Millisecond) // wait for timeout flush
+	cancel()
+	<-done
+
+	total := 0
+	for _, batch := range sink.Flushed {
+		total += len(batch)
+	}
+	if total != 1 {
+		t.Fatalf("expected 1 valid event flushed, got %d", total)
+	}
+}
+
+// TestWorker_SourceError: non-context error from source → worker returns error
+func TestWorker_SourceError(t *testing.T) {
+	src := adapter.NewMockSource()
+	sink := &strategy.MockSink{}
+	w := newTestWorker(src, sink)
+
+	done := runAsync(context.Background(), w)
+	src.PushError(errors.New("kafka connection lost"))
+	err := <-done
+
+	if err == nil {
+		t.Fatal("expected error from worker, got nil")
+	}
+}
+
+// mockCacheReader satisfies schema.CacheReader for validator tests
+type mockCacheReader struct {
+	cities  map[string]int
+	regions map[string]int // key: "cityID|regionName"
+}
+
+func (m *mockCacheReader) GetCityID(city string) int {
+	if id, ok := m.cities[city]; ok {
+		return id
+	}
+	return -1
+}
+
+func (m *mockCacheReader) GetRegionID(cityID int, region string) int {
+	key := fmt.Sprintf("%d|%s", cityID, region)
+	if id, ok := m.regions[key]; ok {
+		return id
+	}
+	return -1
+}

--- a/services/worker-golang/app/strategy/mockSink.go
+++ b/services/worker-golang/app/strategy/mockSink.go
@@ -2,37 +2,38 @@ package strategy
 
 import (
 	"context"
+	"sync"
 
-	"go.uber.org/zap"
-	"safezone.service.worker-golang/app/pkg/logger"
 	"safezone.service.worker-golang/app/schema"
 )
 
+// MockSink captures Flush calls for test assertions.
+// Set FlushError to inject errors.
 type MockSink struct {
-	Logger *logger.ContextLogger
+	mu         sync.Mutex
+	Flushed    [][]schema.CovidEvent
+	FlushError error
 }
 
 func (m *MockSink) Flush(ctx context.Context, buffer *[]schema.CovidEvent) error {
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	default:
-		for _, evt := range *buffer {
-			m.Logger.Debug(ctx, "Flushing event",
-				zap.String("event_type", evt.EventType),
-				zap.String("trace_id", evt.TraceID),
-				zap.String("date", evt.Payload.Date),
-				zap.String("city", evt.Payload.City),
-				zap.String("region", evt.Payload.Region),
-				zap.Int("cases", evt.Payload.Cases))
-		}
-		// clear the buffer after flushing
-		*buffer = (*buffer)[:0]
-		return nil
+	if m.FlushError != nil {
+		return m.FlushError
 	}
+	snapshot := make([]schema.CovidEvent, len(*buffer))
+	copy(snapshot, *buffer)
+	m.mu.Lock()
+	m.Flushed = append(m.Flushed, snapshot)
+	m.mu.Unlock()
+	*buffer = (*buffer)[:0]
+	return nil
+}
+
+func (m *MockSink) FlushedCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.Flushed)
 }
 
 func (m *MockSink) Close(ctx context.Context) error {
-	m.Logger.Info(ctx, "MockSink closed")
 	return nil
 }


### PR DESCRIPTION
## Summary
- Fix memory leak: `defer cancel()` inside `for` loop caused timer accumulation on every iteration
- Fix dead error check: `Flush()` return value was silently discarded
- Remove Java-like OOP scaffolding: `WorkerFactory` struct → `NewWorker()` function, `Orchestrator` struct → `RunWorkers()` function
- Extract `CacheReader` interface in `schema` package so `CovidValidator` no longer depends on concrete `*cache.Cache`
- Upgrade `MockSource` to channel-based control (replaces hardcoded sleep + fixed events)
- Upgrade `MockSink` with `Flushed` capture and `FlushError` injection for assertions
- Add `worker_test.go` (6 cases: batch flush, timeout flush, empty buffer, graceful shutdown, validation reject, source error)
- Add `validator_test.go` (4 cases: valid event, invalid date, unknown city/region, negative cases)
- Wire `Dockerfile.test` and `make test-worker-golang` — closes the only test gap in `test-all` pipeline

## Test plan
- [x] `go test ./...` — GREEN locally
- [x] `make test-worker-golang` — GREEN in container
- [x] `make local-ci` — full pipeline GREEN (build-all → smoke-test 27/27)

## Notes
`RunWorkers` internal parallelism is preserved but documented: effective concurrency is bounded by Kafka partition count, not `parallelN`. Fan-out redesign deferred to v0.5.0 (#23). Horizontal scaling remains owned by KEDA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)