### PR TITLE
fix(dashboard): self-prefix to /dashboard-classic/ for A/B routing

### DIFF
--- a/services/dashboard/app/main.py
+++ b/services/dashboard/app/main.py
@@ -12,8 +12,8 @@ from config.settings import SERVER_IP, SERVER_PORT, SERVICE_NAME, SERVICE_VERSIO
 def create_app():
     app = dash.Dash(
         __name__,
-        routes_pathname_prefix="/dashboard/classic/",
-        requests_pathname_prefix="/dashboard/classic/",
+        routes_pathname_prefix="/dashboard-classic/",
+        requests_pathname_prefix="/dashboard-classic/",
         external_stylesheets=[dbc.themes.FLATLY],
     )
     app.layout = get_dashboard_layout()


### PR DESCRIPTION
## What
Change the classic Plotly Dash UI base path from `/dashboard/classic/` to `/dashboard-classic/` (`routes_pathname_prefix` + `requests_pathname_prefix`).

## Why
Makes classic an element-disjoint sibling of the new SPA at `/dashboard`, so the gateway HTTPRoute resolves the A/B split by longest-prefix precedence — no SPA catch-all swallow, no manual rule ordering. Dash self-prefixes, so the route must NOT strip this path.

## Merge order
Merge LAST — ideally as the first dogfood ride through the new `publish-dev` flow (PR -> dev -> publish `0.3.6-<sha>` -> preview).

Context: .ai-session-drafts/2026-06-07-safezone-0.3.5-network-layer.md §3.1 (backlog #3)