### PR TITLE
feat(ci): freight announcement via PR label

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -46,19 +46,27 @@ jobs:
       # ── Freight issue (IssueOps): announce the candidate (opt-in) ──
       # Images publish on EVERY dev merge (E1), but announcing a candidate for
       # validation is a deliberate act — most merges bundle toward a later
-      # validation, not "validate this one now". Opt in by putting [freight] in
-      # the merge commit message; otherwise the image is published silently.
-      # When announced: opens a deploy-repo issue (the deploy work queue),
-      # init-deploy marks it `validated` on green, the release gate requires
-      # that label, the release run closes it. If skipped here, init-deploy's
-      # find-or-create still makes the issue at validation time. Cross-repo
-      # write needs the PAT (GITHUB_TOKEN is repo-scoped); failure only warns.
+      # validation, not "validate this one now". Opt in by ticking the `freight`
+      # label on the PR before merging (clickable, decided pre-merge, auditable
+      # on the PR); otherwise the image is published silently. When announced:
+      # opens a deploy-repo issue (the deploy work queue), init-deploy marks it
+      # `validated` on green, the release gate requires that label, the release
+      # run closes it. If skipped here, init-deploy's find-or-create still makes
+      # the issue at validation time. Cross-repo write needs the PAT
+      # (GITHUB_TOKEN is repo-scoped); failure only warns.
       - name: Open freight issue in the deploy repo
-        if: ${{ contains(github.event.head_commit.message, '[freight]') }}
         env:
           GH_TOKEN: ${{ secrets.GHCR_TOKEN }}
           DEPLOY_REPO: SafeChord/SafeZone-Deploy
         run: |
+          # Resolve the PR merged by this commit and check for the `freight`
+          # label. No PR / not labeled → silent publish.
+          LABELS=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" \
+            --jq '.[].labels[].name' 2>/dev/null || true)
+          if ! echo "$LABELS" | grep -Fxq "freight"; then
+            echo "PR not labeled 'freight' — image published, no candidate announced."
+            exit 0
+          fi
           TITLE="freight: ${RELEASE_VERSION}"
           EXISTING=$(gh issue list --repo "$DEPLOY_REPO" --label freight --state all \
             --json title --jq '.[].title' || true)


### PR DESCRIPTION
## Summary

Switches the freight-announcement opt-in from a commit-message `[freight]` flag (poor ergonomics — must be typed into the merge dialog, easy to forget) to a **`freight` PR label**. `publish-dev` resolves the PR merged by the push commit (`commits/{sha}/pulls`) and announces the candidate only when the PR carries the label. The decision is now clickable, made pre-merge in the PR sidebar, and visible/auditable on the PR.

Forgetting the label is still safe: `init-deploy`'s find-or-create opens the freight issue at validation time.

## Note
**This PR is itself labeled `freight`** — merging it exercises the new path end-to-end: `publish-dev` (running with the new logic at the merge commit) will open the first live `freight: 0.3.6-<sha>` issue in `SafeZone-Deploy`. That candidate is then the one we repoint preview to, validate, and tag as `v0.3.6`.

## Test plan
- [x] YAML parse
- [ ] GATE 1: PR CI (`make ci-all`)
- [ ] On merge: publish-dev resolves the `freight` label and opens the deploy-repo freight issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)